### PR TITLE
add space after appbar

### DIFF
--- a/src/components/AppBarTop.js
+++ b/src/components/AppBarTop.js
@@ -51,7 +51,7 @@ class AppBarTop extends React.Component {
           <MenuItem onClick={this.handleToggle}>Menu Item 1</MenuItem>
           <MenuItem onClick={this.handleToggle}>Menu Item 2</MenuItem>
         </Drawer>
-
+        <div style={{height: 64}}/>
       </div>
     );
   }

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -19,7 +19,6 @@ class HomePage extends React.Component {
             authenticated
               ?
               <div>
-               <br/><br/><br/>
                 <Container fluid>
                   <Row>
                     <Col sm={9}>


### PR DESCRIPTION
I suggest adding a spacing div after the appbar so that the appbar doesn't cover up the top of whatever component follows. With this change, we can eliminate the 3 \<br/> before the calendar.